### PR TITLE
Fix broken link to tutorial

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -119,4 +119,4 @@ make
 
 ## Tutorial
 
-Once you have Service Catalog installed and GCP broker added to the cluster.  Follow this [basic tutorial](installer/service-catalog-pubsub-tutorial.md) to get started with Service Catalog.
+Once you have Service Catalog installed and GCP broker added to the cluster.  Follow this [basic tutorial](/installer/service-catalog-pubsub-tutorial.md) to get started with Service Catalog.


### PR DESCRIPTION
README has relative path and is broken from https://github.com/GoogleCloudPlatform/k8s-service-catalog/tree/master/installer. Making it absolute fixes the problem. See https://github.com/jpbetz/k8s-service-catalog/tree/patch-1