### PR TITLE
Migrate broker-cli to github

### DIFF
--- a/broker-cli/cmd/broker-cli/main.go
+++ b/broker-cli/cmd/broker-cli/main.go
@@ -1,0 +1,24 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is the main entrance of broker-cli.
+package main
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/broker-cli/pkg/client/adapter/adapter.go
+++ b/broker-cli/pkg/client/adapter/adapter.go
@@ -16,16 +16,30 @@
 // well as various implementations using different protocols.
 package adapter
 
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/osb"
+)
+
 // Adapter is the interface to connect to service brokers and the admin service.
 type Adapter interface {
 	// Admin methods.
-	CreateBroker(params *CreateBrokerParams) ([]byte, error)
-	DeleteBroker(params *DeleteBrokerParams) ([]byte, error)
-	GetBroker(params *GetBrokerParams) ([]byte, error)
-	ListBrokers(params *ListBrokersParams) ([]byte, error)
+	CreateBroker(params *CreateBrokerParams) (*osb.Broker, error)
+	DeleteBroker(params *DeleteBrokerParams) error
+	GetBroker(params *GetBrokerParams) (*osb.Broker, error)
+	ListBrokers(params *ListBrokersParams) (*ListBrokersResult, error)
 
 	// OSB APIs.
+	GetCatalog(params *GetCatalogParams) (*GetCatalogResult, error)
 	CreateInstance(params *CreateInstanceParams) (*CreateInstanceResult, error)
+	DeleteInstance(params *DeleteInstanceParams) (*DeleteInstanceResult, error)
+	UpdateInstance(params *UpdateInstanceParams) (*UpdateInstanceResult, error)
+	InstanceLastOperation(params *InstanceLastOperationParams) (*Operation, error)
+	CreateBinding(params *CreateBindingParams) (*CreateBindingResult, error)
+	DeleteBinding(params *DeleteBindingParams) (*DeleteBindingResult, error)
+	BindingLastOperation(params *BindingLastOperationParams) (*Operation, error)
 }
 
 // CreateBrokerParams is used as input to CreateBroker.
@@ -57,15 +71,54 @@ type ListBrokersParams struct {
 	Project     string
 }
 
+// ListBrokersResult is the output from ListBrokers.
+type ListBrokersResult struct {
+	Brokers []osb.Broker `json:"brokers"`
+}
+
+// OperationType is the enum to represent all the types of OSB operations.
+type OperationType int
+
+const (
+	OperationCreate OperationType = iota
+	OperationUpdate
+	OperationDelete
+	OperationUnknown
+)
+
+// A list of constants to represent all the states of OSB operations.
+const (
+	OperationSucceeded  = "succeeded"
+	OperationFailed     = "failed"
+	OperationInProgress = "in progress"
+)
+
+// GetCatalogParams is used as input to GetCatalog.
+type GetCatalogParams struct {
+	// Server is URL of the broker.
+	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+}
+
+// GetCatalogResult is output of successful GetCatalog request.
+type GetCatalogResult struct {
+	Services []osb.Service
+}
+
 // CreateInstanceParams stores the parameters used to create an instance.
 type CreateInstanceParams struct {
 	// Server is the URL for the broker.
 	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
 	// AcceptsIncomplete indicates whether the client can accept asynchronous provisioning.  If the
 	// broker does not support synchronous/asynchronous provisioning of a service, it will reject a
-	// request with this field set to false/true.
+	// request with this field set to false/true respectively.
 	AcceptsIncomplete bool
-	// InstanceID is the ID of the service instance.  The Open Service Broker API specification
+	// InstanceID is the ID of the service instance. The Open Service Broker API specification
 	// recommends using a GUID for this field.
 	InstanceID string
 	// ServiceID is the ID of the service to use for the service instance.
@@ -93,5 +146,230 @@ type CreateInstanceResult struct {
 	// DashboardURL is the URL of a web-based management user interface for the service instance.
 	DashboardURL string
 	// OperationID is an extra identifier supplied by the broker to identify asynchronous operations.
+	// It should be an empty string if the request is completed synchronously.
 	OperationID string
+}
+
+// DeleteInstanceParams stores the parameters used to delete an instance.
+type DeleteInstanceParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+	// AcceptsIncomplete indicates whether the client can accept asynchronous provisioning.  If the
+	// broker does not support synchronous/asynchronous provisioning of a service, it will reject a
+	// request with this field set to false/true respectively.
+	AcceptsIncomplete bool
+	// InstanceID is the ID of the service instance.  The Open Service Broker API specification
+	// recommends using a GUID for this field.
+	InstanceID string
+	// ServiceID is the ID of the service to use for the service instance.
+	ServiceID string
+	// PlanID is the ID of the plan to use for the service instance.
+	PlanID string
+}
+
+// DeleteInstanceResult is the result of a successful instance deletion request.
+type DeleteInstanceResult struct {
+	// Async indicates whether the broker is handling the deprovision request asynchronously.
+	Async bool
+	// OperationID is an extra identifier supplied by the broker to identify asynchronous operations.
+	// It should be an empty string if the request is completed synchronously.
+	OperationID string
+}
+
+// UpdateInstanceParams stores the parameters used to update an instance.
+type UpdateInstanceParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+	// AcceptsIncomplete indicates whether the client can accept asynchronous update. If the broker
+	// does not support synchronous/asynchronous update of an instance, it will reject a request with
+	// this field set to false/true respectively.
+	AcceptsIncomplete bool
+	// InstanceID is the ID of a previously provisioned service instance.
+	InstanceID string
+	// ServiceID is the ID of the service provisioned by the service instance.
+	ServiceID string
+	// PlanID is the ID of the plan to use for the service instance.
+	PlanID string
+	// Context is the contextual data under which the service instance is created.
+	Context map[string]interface{}
+	// Parameters is the configuration options for the service instance.
+	Parameters map[string]interface{}
+	// PreviousServiceID is the ID of the service provisioned by the service instance.
+	PreviousServiceID string
+	// PreviousPlanID is the ID of the plan prior to the update.
+	PreviousPlanID string
+	// PreviousOrganizationID is the ID of the organization specified for the service instance.
+	PreviousOrganizationID string
+	// PreviousSpaceID is the ID of the space specified for the service instance.
+	PreviousSpaceID string
+}
+
+// UpdateInstanceResult is the result of a successful instance update request.
+type UpdateInstanceResult struct {
+	// Async indicates whether the broker is handling the update request asynchronously.
+	Async bool
+	// OperationID is an extra identifier supplied by the broker to identify asynchronous operations.
+	// It should be an empty string if the request is completed synchronously.
+	OperationID string
+}
+
+// CreateBindingParams stores the parameters used to create a binding.
+type CreateBindingParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+	// AcceptsIncomplete indicates whether the client can accept asynchronous provisioning.  If the
+	// broker does not support synchronous/asynchronous provisioning of a service, it will reject a
+	// request with this field set to false/true respectively.
+	AcceptsIncomplete bool
+	// InstanceID is the ID of the service instance to bind to.
+	InstanceID string
+	// BindingID is the ID of the service binding to be created. The Open Service Broker API
+	// specification recommends using a GUID for this field.
+	BindingID string
+	// ServiceID is the ID of the service to use for the service binding.
+	ServiceID string
+	// PlanID is the ID of the plan to use for the service binding.
+	PlanID string
+	// Context is the contextual information under which the service binding is to be created.
+	Context map[string]interface{}
+	// AppGUID is the GUID of an application associated with the binding to be created. Optional.
+	AppGUID string
+	// BindResource holds extra information about platform resources associated with the binding to
+	// be created. CF-specific. Optional.
+	BindResource map[string]interface{}
+	// Parameters is a set of configuration options for the service binding. Optional.
+	Parameters map[string]interface{}
+}
+
+// CreateBindingResult is the result of a successful binding creation request.
+type CreateBindingResult struct {
+	// Async indicates whether the broker is handling the bind request asynchronously.
+	Async bool
+	// Credentials is a free-form hash of credentials that can be used by applications or users to
+	// access the service.
+	Credentials map[string]interface{}
+	// SyslogDrainURl is a URL to which logs must be streamed. CF-specific. May only be supplied by a
+	// service that declares a requirement for the 'syslog_drain' permission.
+	SyslogDrainURL *string
+	// RouteServiceURL is a URL to which the platform must proxy requests to the application the
+	// binding is for. CF-specific. May only be supplied by a service that declares a requirement for
+	// the 'route_service' permission.
+	RouteServiceURL *string
+	// VolumeMounts is an array of configuration string for mounting volumes. CF-specific. May only be
+	// supplied by a service that declares a requirement for the 'volume_mount' permission.
+	VolumeMounts []interface{}
+	// OperationID is an extra identifier supplied by the broker to identify asynchronous operations.
+	// It should be an empty string if the request is completed synchronously.
+	OperationID string
+}
+
+// DeleteBindingParams stores the parameters used to delete a binding.
+type DeleteBindingParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+	// AcceptsIncomplete indicates whether the client can accept asynchronous provisioning.  If the
+	// broker does not support synchronous/asynchronous provisioning of a service, it will reject a
+	// request with this field set to false/true respectively.
+	AcceptsIncomplete bool
+	// InstanceID is the ID of the service instance to bind to.
+	InstanceID string
+	// BindingID is the ID of the service binding to be created. The Open Service Broker API
+	// specification recommends using a GUID for this field.
+	BindingID string
+	// ServiceID is the ID of the service to use for the service binding.
+	ServiceID string
+	// PlanID is the ID of the plan to use for the service binding.
+	PlanID string
+}
+
+// DeleteBindingResult is the result of a successful binding deletion request.
+type DeleteBindingResult struct {
+	// Async indicates whether the broker is handling the bind request asynchronously.
+	Async bool
+	// OperationID is an extra identifier supplied by the broker to identify asynchronous operations.
+	// It should be an empty string if the request is completed synchronously.
+	OperationID string
+}
+
+// LastOperationParams contains the common params used to poll last operation of the resource.
+type LastOperationParams struct {
+	// APIVersion is the header value associated with the version of the Open Service Broker API used
+	// by the request.
+	APIVersion string
+	// ServiceID is the ID of the service that the resource is created from. Optional, but recommended.
+	ServiceID string
+	// PlanID is the ID of the plan that the resource is created from. Optional, but recommended.
+	PlanID string
+	// OperationID is the operation ID provided by the broker in the response to the initial request.
+	// Optional, but must be sent if supplied in the response to the original request.
+	OperationID string
+	// OperationType is one of Create, Update or Delete.
+	OperationType OperationType
+}
+
+// InstanceLastOperation stores the parameters used to poll the last operation of a service instance.
+type InstanceLastOperationParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// InstanceID is the instance of the service to query the last operation for.
+	InstanceID string
+	// LastOperationParams contains the common params used to poll last operation of the resource.
+	*LastOperationParams
+}
+
+// BindingLastOperation stores the parameters used to poll the last operation of a service binding.
+type BindingLastOperationParams struct {
+	// Server is the URL for the broker.
+	Server string
+	// InstanceID is the instance that the binding binds to.
+	InstanceID string
+	// BindingID is the service binding to query the last operation for.
+	BindingID string
+	// LastOperationParams contains the common params used to poll last operation of the resource.
+	*LastOperationParams
+}
+
+// Operation is the result of a successful operation polling request.
+type Operation struct {
+	// State is the state of the queried operation.
+	State string
+	// Description is a message from the broker describing the current state of the operation.
+	Description string
+}
+
+// BrokerError is the result of a failed broker request.
+type BrokerError struct {
+	// StatusCode is the HTTP status code returned by the broker.
+	StatusCode int
+	// ErrorDescription describes the failed result of the request.
+	ErrorDescription string
+	// ErrorBody is the response body returned by the broker.
+	ErrorBody string
+}
+
+// Error is the method inherited from "error" interface to print the error.
+func (e *BrokerError) Error() string {
+	code := "<nil>"
+	description := "<nil>"
+
+	if e.StatusCode != 0 {
+		code = strconv.Itoa(e.StatusCode)
+	}
+	if e.ErrorDescription != "" {
+		description = e.ErrorDescription
+	}
+
+	return fmt.Sprintf("StatusCode: %s\n Description: %s\n Details: %s", code, description, e.ErrorBody)
 }

--- a/broker-cli/pkg/client/adapter/httpadapter.go
+++ b/broker-cli/pkg/client/adapter/httpadapter.go
@@ -27,7 +27,15 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/osb"
 )
 
-const acceptsIncompleteKey = "accepts_incomplete"
+const (
+	acceptsIncompleteKey = "accepts_incomplete"
+	serviceIDKey         = "service_id"
+	planIDKey            = "plan_id"
+	operationKey         = "operation"
+	instanceKey          = "instance"
+	bindingKey           = "binding"
+	apiVersionHeader     = "X-Broker-API-Version"
+)
 
 type DoClient interface {
 	Do(*http.Request) (*http.Response, error)
@@ -46,7 +54,7 @@ func NewHttpAdapter(client DoClient) *HttpAdapter {
 }
 
 // CreateBroker creates a broker in project with the given name, title, and catalogs using the registryURL.
-func (adapter *HttpAdapter) CreateBroker(params *CreateBrokerParams) ([]byte, error) {
+func (adapter *HttpAdapter) CreateBroker(params *CreateBrokerParams) (*osb.Broker, error) {
 	url := fmt.Sprintf("%s/v1alpha1/projects/%s/brokers", params.RegistryURL, params.Project)
 
 	broker := osb.Broker{
@@ -59,25 +67,51 @@ func (adapter *HttpAdapter) CreateBroker(params *CreateBrokerParams) ([]byte, er
 		return nil, fmt.Errorf("error marshalling the broker %v for body: %v", broker, err)
 	}
 
-	return adapter.doRequest(url, http.MethodPost, bytes.NewReader(postBody))
+	ret := &osb.Broker{}
+	err = adapter.doRequest(url, http.MethodPost, bytes.NewReader(postBody), ret)
+	return ret, err
 }
 
 // DeleteBroker deletes the broker with the given name from the project using registryURL.
-func (adapter *HttpAdapter) DeleteBroker(params *DeleteBrokerParams) ([]byte, error) {
+func (adapter *HttpAdapter) DeleteBroker(params *DeleteBrokerParams) error {
 	url := fmt.Sprintf("%s/v1alpha1/projects/%s/brokers/%s", params.RegistryURL, params.Project, params.Name)
-	return adapter.doRequest(url, http.MethodDelete, nil)
+	return adapter.doRequest(url, http.MethodDelete, nil, nil)
 }
 
 // GetBroker retrieves the broker with the given name and project using the registryURL.
-func (adapter *HttpAdapter) GetBroker(params *GetBrokerParams) ([]byte, error) {
+func (adapter *HttpAdapter) GetBroker(params *GetBrokerParams) (*osb.Broker, error) {
 	url := fmt.Sprintf("%s/v1alpha1/projects/%s/brokers/%s", params.RegistryURL, params.Project, params.Name)
-	return adapter.doRequest(url, http.MethodGet, nil)
+	ret := &osb.Broker{}
+	err := adapter.doRequest(url, http.MethodGet, nil, ret)
+	return ret, err
 }
 
 // ListBrokers lists the brokers of the given project using the registryURL.
-func (adapter *HttpAdapter) ListBrokers(params *ListBrokersParams) ([]byte, error) {
+func (adapter *HttpAdapter) ListBrokers(params *ListBrokersParams) (*ListBrokersResult, error) {
 	url := fmt.Sprintf("%s/v1alpha1/projects/%s/brokers", params.RegistryURL, params.Project)
-	return adapter.doRequest(url, http.MethodGet, nil)
+	ret := &ListBrokersResult{}
+	err := adapter.doRequest(url, http.MethodGet, nil, ret)
+	return ret, err
+}
+
+func (adapter *HttpAdapter) GetCatalog(params *GetCatalogParams) (*GetCatalogResult, error) {
+	url := fmt.Sprintf("%s/v2/catalog", params.Server)
+
+	statusCode, body, err := adapter.doOSBRequest(url, http.MethodGet, params.APIVersion, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != 200 {
+		return nil, validateGCPFailureResponse(body, statusCode, "error fetching catalog")
+	}
+
+	res := &GetCatalogResult{}
+	err = json.Unmarshal(body, res)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(body), err)
+	}
+	return res, nil
 }
 
 // CreateInstance calls the given server to provision a service instance using the request information.
@@ -96,81 +130,337 @@ func (adapter *HttpAdapter) CreateInstance(params *CreateInstanceParams) (*Creat
 	putParams := url.Values{}
 	putParams.Set(acceptsIncompleteKey, strconv.FormatBool(params.AcceptsIncomplete))
 
-	respCode, respBody, err := adapter.doOSBRequest(instanceURL, http.MethodPut, putBody, putParams)
+	respCode, respBody, err := adapter.doOSBRequest(instanceURL, http.MethodPut, params.APIVersion, putBody, putParams)
 	if err != nil {
 		return nil, err
+	}
+
+	unmarshalSuccessResponse := func(body []byte, isAsync bool) (*CreateInstanceResult, error) {
+		rb := &osb.ProvisionResponseBody{}
+		err := json.Unmarshal(body, rb)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(body), err)
+		}
+		return &CreateInstanceResult{Async: isAsync, DashboardURL: rb.DashboardURL, OperationID: rb.Operation}, nil
 	}
 
 	switch respCode {
 	case http.StatusOK, http.StatusCreated:
 		// Identical service instance already exists, or service instance is provisioned synchronously.
-		rb := &osb.ProvisionResponseBody{}
-		err = json.Unmarshal(respBody, rb)
-		if err != nil {
-			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(respBody), err)
-		}
-		return &CreateInstanceResult{Async: false, DashboardURL: rb.DashboardURL, OperationID: rb.Operation}, nil
+		return unmarshalSuccessResponse(respBody, false)
 	case http.StatusAccepted:
 		// Service instance is being provisioned asynchronously.
 		if !params.AcceptsIncomplete {
 			return nil, fmt.Errorf("request shouldn't be handled asynchronously: %s", string(respBody))
 		}
 
-		rb := &osb.ProvisionResponseBody{}
+		return unmarshalSuccessResponse(respBody, true)
+	case http.StatusBadRequest:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusConflict:
+		return nil, validateGCPFailureResponse(respBody, respCode, "instance with the same id but different attributes already exists")
+	case http.StatusUnprocessableEntity:
+		return nil, validateGCPFailureResponse(respBody, respCode, "the broker only supports asynchronous requests")
+	default:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
+	}
+}
+
+// DeleteInstance calls the given server to deprovision a service instance using the request information.
+func (adapter *HttpAdapter) DeleteInstance(params *DeleteInstanceParams) (*DeleteInstanceResult, error) {
+	instanceURL := fmt.Sprintf("%s/v2/service_instances/%s", params.Server, params.InstanceID)
+
+	deleteParams := url.Values{}
+	deleteParams.Set(serviceIDKey, params.ServiceID)
+	deleteParams.Set(planIDKey, params.PlanID)
+	deleteParams.Set(acceptsIncompleteKey, strconv.FormatBool(params.AcceptsIncomplete))
+
+	respCode, respBody, err := adapter.doOSBRequest(instanceURL, http.MethodDelete, params.APIVersion, nil, deleteParams)
+	if err != nil {
+		return nil, err
+	}
+
+	switch respCode {
+	case http.StatusOK, http.StatusGone:
+		// The service instance is deprovisioned synchronously, or it doesn't exist.
+		// The response should be an empty JSON object ("{}") with no data.
+		return &DeleteInstanceResult{Async: false}, nil
+	case http.StatusAccepted:
+		// The service instance is being deprovisioned asynchronously.
+		if !params.AcceptsIncomplete {
+			return nil, fmt.Errorf("request shouldn't be handled asynchronously: %s", string(respBody))
+		}
+
+		rb := &osb.DeprovisionResponseBody{}
+		err := json.Unmarshal(respBody, rb)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(respBody), err)
+		}
+		return &DeleteInstanceResult{Async: true, OperationID: rb.Operation}, nil
+	case http.StatusBadRequest:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusUnprocessableEntity:
+		return nil, validateGCPFailureResponse(respBody, respCode, "the broker only supports asynchronous requests")
+	default:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
+	}
+}
+
+// UpdateInstance calls the given server to update a service instance using the request information.
+func (adapter *HttpAdapter) UpdateInstance(params *UpdateInstanceParams) (*UpdateInstanceResult, error) {
+	instanceURL := fmt.Sprintf("%s/v2/service_instances/%s", params.Server, params.InstanceID)
+
+	patchBody := &osb.UpdateInstanceRequestBody{
+		ServiceID:  params.ServiceID,
+		PlanID:     params.PlanID,
+		Context:    params.Context,
+		Parameters: params.Parameters,
+		PreviousValues: &osb.UpdateInstancePreviousValues{
+			ServiceID:      params.PreviousServiceID,
+			PlanID:         params.PreviousPlanID,
+			OrganizationID: params.PreviousOrganizationID,
+			SpaceID:        params.PreviousSpaceID,
+		},
+	}
+
+	patchParams := url.Values{}
+	patchParams.Set(acceptsIncompleteKey, strconv.FormatBool(params.AcceptsIncomplete))
+
+	respCode, respBody, err := adapter.doOSBRequest(instanceURL, http.MethodPatch, params.APIVersion, patchBody, patchParams)
+	if err != nil {
+		return nil, err
+	}
+
+	unmarshalSuccessResponse := func(body []byte, isAsync bool) (*UpdateInstanceResult, error) {
+		rb := &osb.UpdateInstanceResponseBody{}
+		err := json.Unmarshal(body, rb)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(body), err)
+		}
+		return &UpdateInstanceResult{Async: isAsync, OperationID: rb.Operation}, nil
+	}
+
+	switch respCode {
+	case http.StatusOK:
+		// Requested changes have been applied.
+		return unmarshalSuccessResponse(respBody, false)
+	case http.StatusAccepted:
+		// Service instance is being updated asynchronously.
+		if !params.AcceptsIncomplete {
+			return nil, fmt.Errorf("request shouldn't be handled asynchronously: %s", string(respBody))
+		}
+
+		return unmarshalSuccessResponse(respBody, true)
+	case http.StatusBadRequest:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusUnprocessableEntity:
+		return nil, validateGCPFailureResponse(respBody, respCode, "the broker only supports asynchronous requests")
+	default:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
+	}
+}
+
+// InstanceLastOperation calls the given server to get the state of the last operation for the
+// service instance.
+func (adapter *HttpAdapter) InstanceLastOperation(params *InstanceLastOperationParams) (*Operation, error) {
+	operationURL := fmt.Sprintf("%s/v2/service_instances/%s/last_operation", params.Server, params.InstanceID)
+	return adapter.lastOperation(instanceKey, operationURL, params.LastOperationParams)
+}
+
+// CreateBinding calls the given server to bind to a service instance using the request information.
+func (adapter *HttpAdapter) CreateBinding(params *CreateBindingParams) (*CreateBindingResult, error) {
+	bindingURL := fmt.Sprintf("%s/v2/service_instances/%s/service_bindings/%s", params.Server, params.InstanceID, params.BindingID)
+
+	putBody := &osb.BindRequestBody{
+		ServiceID:    params.ServiceID,
+		PlanID:       params.PlanID,
+		Context:      params.Context,
+		AppGUID:      params.AppGUID,
+		BindResource: params.BindResource,
+		Parameters:   params.Parameters,
+	}
+
+	putParams := url.Values{}
+	putParams.Set(acceptsIncompleteKey, strconv.FormatBool(params.AcceptsIncomplete))
+
+	respCode, respBody, err := adapter.doOSBRequest(bindingURL, http.MethodPut, params.APIVersion, putBody, putParams)
+	if err != nil {
+		return nil, err
+	}
+
+	marshalSuccessResponse := func(body []byte, isAsync bool) (*CreateBindingResult, error) {
+		rb := &osb.BindResponseBody{}
+		err := json.Unmarshal(body, rb)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(body), err)
+		}
+		return &CreateBindingResult{
+			Async:           isAsync,
+			Credentials:     rb.Credentials,
+			SyslogDrainURL:  rb.SyslogDrainURL,
+			RouteServiceURL: rb.RouteServiceURL,
+			VolumeMounts:    rb.VolumeMounts,
+			OperationID:     rb.Operation,
+		}, nil
+	}
+
+	switch respCode {
+	case http.StatusOK, http.StatusCreated:
+		// Identical service binding already exists, or service binding is created synchronously.
+		return marshalSuccessResponse(respBody, false)
+	case http.StatusAccepted:
+		// Service binding is being created asynchronously.
+		if !params.AcceptsIncomplete {
+			return nil, fmt.Errorf("request shouldn't be handled asynchronously: %s", string(respBody))
+		}
+		return marshalSuccessResponse(respBody, true)
+	case http.StatusBadRequest:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusConflict:
+		return nil, validateGCPFailureResponse(respBody, respCode, "binding with the same id but different attributes already exists")
+	case http.StatusUnprocessableEntity:
+		return nil, validateGCPFailureResponse(respBody, respCode, "the broker only supports asynchronous requests")
+	default:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
+	}
+}
+
+// DeleteBinding calls the given server to unbind to a service instance using the request information.
+func (adapter *HttpAdapter) DeleteBinding(params *DeleteBindingParams) (*DeleteBindingResult, error) {
+	bindingURL := fmt.Sprintf("%s/v2/service_instances/%s/service_bindings/%s", params.Server, params.InstanceID, params.BindingID)
+
+	deleteParams := url.Values{}
+	deleteParams.Set(serviceIDKey, params.ServiceID)
+	deleteParams.Set(planIDKey, params.PlanID)
+	deleteParams.Set(acceptsIncompleteKey, strconv.FormatBool(params.AcceptsIncomplete))
+
+	respCode, respBody, err := adapter.doOSBRequest(bindingURL, http.MethodDelete, params.APIVersion, nil, deleteParams)
+	if err != nil {
+		return nil, err
+	}
+
+	switch respCode {
+	case http.StatusOK, http.StatusGone:
+		// The service binding is deleted synchronously, or it doesn't exist.
+		// The response should be an empty JSON object ("{}") with no data.
+		return &DeleteBindingResult{Async: false}, nil
+	case http.StatusAccepted:
+		// The service binding is being deleted asynchronously.
+		if !params.AcceptsIncomplete {
+			return nil, fmt.Errorf("request shouldn't be handled asynchronously: %s", string(respBody))
+		}
+
+		rb := &osb.UnbindResponseBody{}
+		err := json.Unmarshal(respBody, rb)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(respBody), err)
+		}
+		return &DeleteBindingResult{Async: true, OperationID: rb.Operation}, nil
+	case http.StatusBadRequest:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusUnprocessableEntity:
+		return nil, validateGCPFailureResponse(respBody, respCode, "the broker only supports asynchronous requests")
+	default:
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
+	}
+}
+
+// BindingLastOperation calls the given server to get the state of the last operation for the
+// service binding.
+func (adapter *HttpAdapter) BindingLastOperation(params *BindingLastOperationParams) (*Operation, error) {
+	operationURL := fmt.Sprintf("%s/v2/service_instances/%s/service_bindings/%s/last_operation", params.Server, params.InstanceID, params.BindingID)
+	return adapter.lastOperation(bindingKey, operationURL, params.LastOperationParams)
+}
+
+func (adapter *HttpAdapter) lastOperation(resource, operationURL string, params *LastOperationParams) (*Operation, error) {
+	getParams := url.Values{}
+	if params.ServiceID != "" {
+		getParams.Set(serviceIDKey, params.ServiceID)
+	}
+	if params.PlanID != "" {
+		getParams.Set(planIDKey, params.PlanID)
+	}
+	if params.OperationID != "" {
+		getParams.Set(operationKey, params.OperationID)
+	}
+
+	respCode, respBody, err := adapter.doOSBRequest(operationURL, http.MethodGet, params.APIVersion, nil, getParams)
+	if err != nil {
+		return nil, err
+	}
+
+	switch respCode {
+	case http.StatusOK:
+		rb := &osb.OperationResponseBody{}
 		err = json.Unmarshal(respBody, rb)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshalling response body: %s\nerror: %v", string(respBody), err)
 		}
-		return &CreateInstanceResult{Async: true, DashboardURL: rb.DashboardURL, OperationID: rb.Operation}, nil
+		return &Operation{State: rb.State, Description: rb.Description}, nil
 	case http.StatusBadRequest:
-		return nil, fmt.Errorf("request was malformed or missing mandatory data: %s", string(respBody))
-	case http.StatusConflict:
-		return nil, fmt.Errorf("service instance with the same id and different attributes already exists: %s", string(respBody))
-	case http.StatusUnprocessableEntity:
-		return nil, fmt.Errorf("the broker only supports asynchronous requests: %s", string(respBody))
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was malformed or missing mandatory data")
+	case http.StatusGone:
+		if params.OperationType == OperationDelete {
+			return &Operation{State: OperationSucceeded, Description: fmt.Sprintf("The %s doesn't exist.", resource)}, nil
+		}
+
+		return nil, validateGCPFailureResponse(respBody, respCode, fmt.Sprintf("%s doesn't exist", resource))
 	default:
-		return nil, fmt.Errorf("request was not successful: %v", string(respBody))
+		return nil, validateGCPFailureResponse(respBody, respCode, "request was not successful")
 	}
 }
 
 // doRequst is a helper function that performs the request, reads the body, checks the status code,
 // and returns an appropriate error message if anything goes wrong.
-func (adapter *HttpAdapter) doRequest(url, method string, reqBody io.Reader) ([]byte, error) {
+// v should be a pointer to the struct that we want to unmarshal the body into.
+func (adapter *HttpAdapter) doRequest(url, method string, reqBody io.Reader, v interface{}) error {
 	req, err := http.NewRequest(method, url, reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("error creating request: %v", err)
+		return fmt.Errorf("error creating request: %v", err)
 	}
 	resp, err := adapter.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error executing request: %v; error: %v", req, err)
+		return fmt.Errorf("error executing request: %v; error: %v", req, err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error reading response body: %v", err)
+		return fmt.Errorf("error reading response body: %v", err)
 	}
 
 	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
-		return nil, fmt.Errorf("request was not successful: %v", string(body))
+		return fmt.Errorf("request was not successful: %v", string(body))
 	}
 
-	return body, nil
+	if v != nil {
+		err = json.Unmarshal(body, v)
+		if err != nil {
+			return fmt.Errorf("error unmarshalling response body into v\nBody: %s\nError: %v", string(body), err)
+		}
+	}
+	return nil
 }
 
 // TODO(maqiuyu): Merge doRequest and doOSBRequest.
 // doOSBRequst is a helper function that performs the OSB request, reads the response body, and
 // returns the response status code and response body.
-func (adapter *HttpAdapter) doOSBRequest(url, method string, reqBody interface{}, reqParams url.Values) (int, []byte, error) {
-	serializedReqBody, err := json.Marshal(reqBody)
-	if err != nil {
-		return 0, nil, fmt.Errorf("error marshalling the request body %+v: %v", reqBody, err)
+func (adapter *HttpAdapter) doOSBRequest(url, method, apiVersion string, reqBody interface{}, reqParams url.Values) (int, []byte, error) {
+	var streamedBody io.Reader
+	if reqBody != nil {
+		serializedReqBody, err := json.Marshal(reqBody)
+		if err != nil {
+			return 0, nil, fmt.Errorf("error marshalling the request body %+v: %v", reqBody, err)
+		}
+
+		streamedBody = bytes.NewReader(serializedReqBody)
 	}
 
-	req, err := http.NewRequest(method, url, bytes.NewReader(serializedReqBody))
+	req, err := http.NewRequest(method, url, streamedBody)
 	if err != nil {
 		return 0, nil, fmt.Errorf("error creating request: %v", err)
 	}
 	req.URL.RawQuery = reqParams.Encode()
+	req.Header.Add(apiVersionHeader, apiVersion)
 
 	resp, err := adapter.client.Do(req)
 	if err != nil {
@@ -183,4 +473,34 @@ func (adapter *HttpAdapter) doOSBRequest(url, method string, reqBody interface{}
 	}
 
 	return resp.StatusCode, body, nil
+}
+
+// TODO(maqiuyu): Add methods to handle non-GCP errors.
+func validateGCPFailureResponse(body []byte, code int, desc string) error {
+	rb := &gcpBrokerFailureResponseBody{}
+	err := json.Unmarshal(body, rb)
+	if err != nil {
+		return &BrokerError{StatusCode: code, ErrorDescription: "error unmarshalling failure response body", ErrorBody: string(body)}
+	}
+
+	return &BrokerError{
+		StatusCode:       code,
+		ErrorDescription: desc,
+		ErrorBody:        string(body),
+	}
+}
+
+type gcpBrokerFailureResponseBody struct {
+	Error *gcpBrokerError `json:"error,omitempty"`
+}
+
+type gcpBrokerError struct {
+	Code    int            `json:"code,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Status  string         `json:"status,omitempty"`
+	Details []*errorDetail `json:"details,omitempty"`
+}
+
+type errorDetail struct {
+	Detail *string `json:"detail,omitempty"`
 }

--- a/broker-cli/pkg/client/osb/types.go
+++ b/broker-cli/pkg/client/osb/types.go
@@ -11,15 +11,77 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Pakcage osb contains the type definitions of OSB abstractions.
 package osb
 
+// Broker is a Service Broker.
 type Broker struct {
 	Name     string   `json:"name"`
 	Title    string   `json:"title,omitempty"`
 	Catalogs []string `json:"catalogs"`
 	URL      *string  `json:"url,omitempty"`
+}
+
+// DashboardClient corresponds to a Dashboard Client Object in the Open Service Broker API.
+type DashboardClient struct {
+	// ID is the ID of the OAuth client that the dashboard will use.
+	ID     *string `json:"id"`
+	Secret *string `json:"secret"`
+	// RedirectURI is a URI for the service dashboard.
+	RedirectURI *string `json:"redirect_uri"`
+}
+
+// Plan corresponds to the Plan Object in the Open Service Broker API.
+type Plan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Metadata    []byte `json:"metadata"`
+	// Free is true if the plan is free and false is paid.
+	// The OSB API specifies the default to be true so nil corresponds with true.
+	Free *bool `json:"free"`
+	// Bindable specifies whether the plan can be bound to. If not specified, then consumers
+	// should use the Bindalbe property from the Service.
+	Bindable *bool    `json:"bindable"`
+	Schemas  *Schemas `json:"schemas"`
+}
+
+// Schemas contains the schemas for the service instance and service bindings of a plan.
+type Schemas struct {
+	ServiceInstance *ServiceInstanceSchema `json:"service_instance"`
+	ServiceBinding  *ServiceBindingSchema  `json:"service_binding"`
+}
+
+// Service corresponds to the Service Object in the Open Service Broker API.
+type Service struct {
+	Name        string   `json:"name"`
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+	// Requires is a list of permisisons a user would have to give to the service to provision
+	// it.
+	Requires []string `json:"requires"`
+	// Bindable specifies the default value for the Bindable property of its Plans.
+	Bindable        bool             `json:"bindable"`
+	Metadata        []byte           `json:"metadata"`
+	DashboardClient *DashboardClient `json:"dashboard_client"`
+	// PlanUpdateable is true iff the service supports up/downgrade of some plans.
+	PlanUpdateable bool `json:"plan_updateable"`
+	// Plans is a list of plans for this service.
+	Plans []Plan `json:"plans"`
+}
+
+// ServiceBindingSchema is the schema for a service binding.
+type ServiceBindingSchema struct {
+	// Create is the json schema describing binding creation.
+	Create *map[string]interface{} `json:"create"`
+}
+
+// ServiceInstanceSchema is the schema for a service instance.
+type ServiceInstanceSchema struct {
+	// Create is the json schema describing instance creation.
+	Create *map[string]interface{} `json:"create"`
+	// Update is the json schema describing instance update.
+	Update *map[string]interface{} `json:"update"`
 }
 
 // ProvisionRequestBody contains the serialized request body to provision a service instance.
@@ -48,4 +110,96 @@ type ProvisionResponseBody struct {
 	DashboardURL string `json:"dashboard_url,omitempty"`
 	// Operation is an extra identifier supplied by the broker to identify asynchronous operations.
 	Operation string `json:"operation,omitempty"`
+}
+
+// DeprovisionResponseBody is the response body for a successful deprovision request.
+type DeprovisionResponseBody struct {
+	// Operation is an extra identifier supplied by the broker to identify asynchronous operations.
+	Operation string `json:"operation,omitempty"`
+}
+
+// UpdateInstanceRequestBody contains the serialized request body to update a service instance.
+type UpdateInstanceRequestBody struct {
+	// ServiceID is the ID of the service used by the service instance.
+	ServiceID string `json:"service_id"`
+	// PlanID is the ID of the plan to use for the service instance.
+	PlanID string `json:"plan_id,omitempty"`
+	// Context is platform-specific contextual information under which the service instance is to be
+	// provisioned. Context was added in version 2.12 of the OSB API and is only sent for versions
+	// 2.12 or later. Optional.
+	Context map[string]interface{} `json:"context,omitempty"`
+	// Parameters is a set of configuration options for the service instance. Optional.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// PreviousValues stores the information about the service instance prior to the update.
+	PreviousValues *UpdateInstancePreviousValues `json:"previous_values,omitempty"`
+}
+
+// UpdateInstancePreviousValues stores the information of a service instance prior to the update.
+type UpdateInstancePreviousValues struct {
+	// ServiceID is the ID of the service used by the service instance. This field is deprecated
+	// because it should be immutable.
+	ServiceID string `json:"service_id,omitempty"`
+	// PlanID is the ID of the plan used by the service instance prior to the update. Optional.
+	PlanID string `json:"plan_id,omitempty"`
+	// OrganizationID is the ID of the organization specified for the service instance. CF-specific.
+	// Optional.
+	OrganizationID string `json:"organization_id,omitempty"`
+	// SpaceID is the ID of the space specified for the service instance. CF-specific. Optional.
+	SpaceID string `json:"space_id,omitempty"`
+}
+
+// UpdateInstanceResponseBody is the response body for a successful update instance request.
+type UpdateInstanceResponseBody struct {
+	// Operation is an extra identifier supplied by the broker to identify asynchronous operations.
+	Operation string `json:"operation,omitempty"`
+}
+
+// BindRequestBody contains the serialized request body to create a service binding.
+type BindRequestBody struct {
+	// ServiceID is the ID of the service to use for the service binding.
+	ServiceID string `json:"service_id"`
+	// PlanID is the ID of the plan to use for the service binding.
+	PlanID string `json:"plan_id"`
+	// Context is the contextual information under which the service binding is to be created.
+	Context map[string]interface{} `json:"context,omitempty"`
+	// AppGUID is the GUID of an application associated with the binding to be created. Optional.
+	AppGUID string `json:"app_guid,omitempty"`
+	// BindResource holds extra information about platform resources associated with the binding to
+	// be created. CF-specific. Optional.
+	BindResource map[string]interface{} `json:"bind_resource,omitempty"`
+	// Parameters is a set of configuration options for the service binding. Optional.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// BindResponseBody is the response body for a successful bind request.
+type BindResponseBody struct {
+	// Credentials is a free-form hash of credentials that can be used by applications or users to
+	// access the service.
+	Credentials map[string]interface{} `json:"credentials,omitempty"`
+	// SyslogDrainURl is a URL to which logs must be streamed. CF-specific. May only be supplied by a
+	// service that declares a requirement for the 'syslog_drain' permission.
+	SyslogDrainURL *string `json:"syslog_drain_url,omitempty"`
+	// RouteServiceURL is a URL to which the platform must proxy requests to the application the
+	// binding is for. CF-specific. May only be supplied by a service that declares a requirement for
+	// the 'route_service' permission.
+	RouteServiceURL *string `json:"route_service_url,omitempty"`
+	// VolumeMounts is an array of configuration string for mounting volumes. CF-specific. May only be
+	// supplied by a service that declares a requirement for the 'volume_mount' permission.
+	VolumeMounts []interface{} `json:"volume_mounts,omitempty"`
+	// Operation is an extra identifier supplied by the broker to identify asynchronous operations.
+	Operation string `json:"operation,omitempty"`
+}
+
+// UnbindResponseBody is the response body for a successful unbind request.
+type UnbindResponseBody struct {
+	// Operation is an extra identifier supplied by the broker to identify asynchronous operations.
+	Operation string `json:"operation,omitempty"`
+}
+
+// OperationResponseBody is the response body for a successful operation polling request.
+type OperationResponseBody struct {
+	// State is the state of the queried operation.
+	State string `json:"state"`
+	// Description is a message from the broker describing the current state of the operation.
+	Description string `json:"description,omitempty"`
 }

--- a/broker-cli/pkg/cmd/bindings.go
+++ b/broker-cli/pkg/cmd/bindings.go
@@ -1,0 +1,240 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/adapter"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bindingsFlags struct {
+		flags.BrokerURLConstructor
+		apiVersion        string
+		instanceID        string
+		bindingID         string
+		acceptsIncomplete bool
+		wait              bool
+		serviceID         string
+		planID            string
+		context           string
+		bindResource      string
+		appGUID           string
+		parameters        string
+		operationID       string
+	}
+
+	// bindingsCmd represents the bindings command.
+	bindingsCmd = &cobra.Command{
+		Use:   "bindings",
+		Short: "Manage service bindings",
+		Long:  "Manage service bindings",
+	}
+
+	bindingsCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a service binding",
+		Long:  "Create a service binding",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&bindingsFlags.instanceID, &bindingsFlags.bindingID, &bindingsFlags.serviceID, &bindingsFlags.planID)
+
+			client := httpAdapterFromFlag()
+			res, err := client.CreateBinding(&adapter.CreateBindingParams{
+				Server:            bindingsFlags.BrokerURL(),
+				APIVersion:        bindingsFlags.apiVersion,
+				AcceptsIncomplete: bindingsFlags.acceptsIncomplete,
+				InstanceID:        bindingsFlags.instanceID,
+				BindingID:         bindingsFlags.bindingID,
+				ServiceID:         bindingsFlags.serviceID,
+				PlanID:            bindingsFlags.planID,
+				Context:           parseStringToObjectMap(bindingsFlags.context),
+				AppGUID:           bindingsFlags.appGUID,
+				BindResource:      parseStringToObjectMap(bindingsFlags.bindResource),
+				Parameters:        parseStringToObjectMap(bindingsFlags.parameters),
+			})
+			if err != nil {
+				log.Fatalf("Error creating binding %s: %v", bindingsFlags.bindingID, err)
+			}
+
+			if !res.Async {
+				fmt.Printf("Successfully created the binding %s: %+v\n", bindingsFlags.bindingID, *res)
+				return
+			}
+
+			if !bindingsFlags.wait {
+				fmt.Printf("Successfully started the operation to create the binding %s: %+v\n", bindingsFlags.bindingID, *res)
+				return
+			}
+
+			op, err := waitOnOperation(res.OperationID, adapter.OperationCreate, client, pollBindingLastOperation)
+			if err != nil {
+				log.Fatalf("Error polling last operation %q for binding %s: %v", res.OperationID, bindingsFlags.bindingID, err)
+			}
+
+			if op.State == adapter.OperationSucceeded {
+				fmt.Printf("Successfully created the binding %s asynchronously (operation %q): %+v\n", bindingsFlags.bindingID, res.OperationID, *op)
+				return
+			}
+
+			log.Fatalf("Failed creating binding %s asynchronously (operation %q): %+v\n", bindingsFlags.bindingID, res.OperationID, *op)
+		},
+	}
+
+	bindingsDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a service binding",
+		Long:  "Delete a service binding",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&bindingsFlags.instanceID, &bindingsFlags.bindingID, &bindingsFlags.serviceID, &bindingsFlags.planID)
+
+			client := httpAdapterFromFlag()
+
+			res, err := client.DeleteBinding(&adapter.DeleteBindingParams{
+				Server:            bindingsFlags.BrokerURL(),
+				APIVersion:        bindingsFlags.apiVersion,
+				AcceptsIncomplete: bindingsFlags.acceptsIncomplete,
+				InstanceID:        bindingsFlags.instanceID,
+				BindingID:         bindingsFlags.bindingID,
+				ServiceID:         bindingsFlags.serviceID,
+				PlanID:            bindingsFlags.planID,
+			})
+			if err != nil {
+				log.Fatalf("Error deleting binding %s: %v", bindingsFlags.bindingID, err)
+			}
+
+			if !res.Async {
+				fmt.Printf("Successfully deleted the binding %s: %+v\n", bindingsFlags.bindingID, *res)
+
+				return
+			}
+
+			if !bindingsFlags.wait {
+				fmt.Printf("Successfully started the operation to delete the binding %s: %+v\n", bindingsFlags.bindingID, *res)
+				return
+			}
+
+			op, err := waitOnOperation(res.OperationID, adapter.OperationDelete, client, pollBindingLastOperation)
+			if err != nil {
+				log.Fatalf("Error polling last operation %q for binding %s: %v", res.OperationID, bindingsFlags.bindingID, err)
+			}
+
+			if op.State == adapter.OperationSucceeded {
+				fmt.Printf("Successfully deleted the binding %s asynchronously (operation %q): %+v\n", bindingsFlags.bindingID, res.OperationID, *op)
+				return
+			}
+
+			log.Fatalf("Failed deleting binding %s asynchronously (operation %q): %+v\n", bindingsFlags.bindingID, res.OperationID, *op)
+		},
+	}
+
+	bindingsPollCmd = &cobra.Command{
+		Use:   "poll",
+		Short: "Poll the operation for the service binding",
+		Long:  "Poll the operation for the service binding",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&bindingsFlags.instanceID, &bindingsFlags.bindingID)
+
+			client := httpAdapterFromFlag()
+			op, err := pollBindingLastOperation(bindingsFlags.operationID, adapter.OperationUnknown, client)
+			if err != nil {
+				log.Fatalf("Error polling operation %q for binding %s: %v", bindingsFlags.operationID, bindingsFlags.bindingID, err)
+			}
+
+			fmt.Printf("Successfully polled the operation %q for binding %s: %+v\n", bindingsFlags.operationID, bindingsFlags.bindingID, *op)
+		},
+	}
+)
+
+func init() {
+	// Flags for `bindings` command group and all subgroups.
+	flags.StringFlag(bindingsCmd.PersistentFlags(), &bindingsFlags.Server, flags.ServerLongName, flags.ServerShortName,
+		fmt.Sprintf("[Required if %s and %s are not given] Broker URL to make request to (https://...).", flags.ProjectLongName, flags.BrokerLongName))
+	flags.StringFlag(bindingsCmd.PersistentFlags(), &bindingsFlags.instanceID, "instance", "i",
+		"[Required] Service instance ID.")
+	flags.StringFlag(bindingsCmd.PersistentFlags(), &bindingsFlags.bindingID, "binding", "d",
+		"[Required] Service binding ID.")
+	flags.StringFlagWithDefault(bindingsCmd.PersistentFlags(), &bindingsFlags.apiVersion,
+		flags.ApiVersionLongName, flags.ApiVersionShortName, flags.ApiVersionDefault, flags.ApiVersionDescription)
+	flags.StringFlag(bindingsCmd.PersistentFlags(), &bindingsFlags.Project, flags.ProjectLongName, flags.ProjectShortName,
+		fmt.Sprintf("[Required if %s is not given] the GCP project of the broker", flags.ServerLongName))
+	flags.StringFlag(bindingsCmd.PersistentFlags(), &bindingsFlags.Broker, flags.BrokerLongName, flags.BrokerShortName,
+		fmt.Sprintf("[Required if %s is not given] the broker name", flags.ServerLongName))
+	bindingsCmd.PersistentFlags().StringVar(&bindingsFlags.Host, flags.HostLongName, flags.HostBrokerDefault, "")
+	bindingsCmd.PersistentFlags().MarkHidden(flags.HostLongName)
+
+	// Flags for `bindings create` command group.
+	flags.BoolFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.acceptsIncomplete, "asynchronous", "a",
+		"[Optional] If specified, the broker will execute the request asynchronously. (Default: FALSE)")
+	flags.BoolFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.wait, "wait", "w",
+		"[Optional] If specified, the broker will keep polling the last operation when the broker "+
+			"is executing the operation asynchronously. (Default: FALSE)")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.serviceID, "service", "r",
+		"[Required] The service ID used to create the service binding.")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.planID, "plan", "l",
+		"[Required] The plan ID used to create the service binding.")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.context, "context", "t",
+		"[Optional] [JSON Object] Contextual information under which the service binding is to be created.")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.bindResource, "bindresource", "e",
+		"[Optional] [JSON Object] Data for platform resources associated with the binding to be created.")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.appGUID, "app", "g",
+		"[Optional] [Deprecated in favor of 'binding_resource'.'app_guid']  GUID of an application "+
+			"associated with the binding to be created.")
+	flags.StringFlag(bindingsCreateCmd.PersistentFlags(), &bindingsFlags.parameters, "parameters", "m",
+		"[Optional] [JSON Object] Configuration options for the service binding.")
+
+	// Flags for `bindings delete` command group.
+	flags.BoolFlag(bindingsDeleteCmd.PersistentFlags(), &bindingsFlags.acceptsIncomplete, "asynchronous", "a",
+		"[Optional] If specified, the broker will execute the request asynchronously. (Default: FALSE)")
+	flags.BoolFlag(bindingsDeleteCmd.PersistentFlags(), &bindingsFlags.wait, "wait", "w",
+		"[Optional] If specified, the broker will keep polling the last operation when the broker "+
+			"is executing the operation asynchronously. (Default: FALSE)")
+	flags.StringFlag(bindingsDeleteCmd.PersistentFlags(), &bindingsFlags.serviceID, "service", "r",
+		"[Required] The service ID used by the service binding.")
+	flags.StringFlag(bindingsDeleteCmd.PersistentFlags(), &bindingsFlags.planID, "plan", "l",
+		"[Required] The plan ID used by the service binding.")
+
+	// Flags for `bindings poll` command group.
+	flags.StringFlag(bindingsPollCmd.PersistentFlags(), &bindingsFlags.serviceID, "service", "r",
+		"[Optional] The service ID used to create the service binding. If present, must not be an empty string.")
+	flags.StringFlag(bindingsPollCmd.PersistentFlags(), &bindingsFlags.planID, "plan", "l",
+		"[Optional] The plan ID used to create the service binding. If present, must not be an empty string.")
+	flags.StringFlag(bindingsPollCmd.PersistentFlags(), &bindingsFlags.operationID, "operation", "o",
+		"[Optional] The operation ID used to poll the operation for the service binding. If present, must not be an empty string.")
+
+	RootCmd.AddCommand(bindingsCmd)
+	bindingsCmd.AddCommand(bindingsCreateCmd)
+	bindingsCmd.AddCommand(bindingsDeleteCmd)
+	bindingsCmd.AddCommand(bindingsPollCmd)
+}
+
+func pollBindingLastOperation(opID string, opType adapter.OperationType, client adapter.Adapter) (*adapter.Operation, error) {
+	return client.BindingLastOperation(&adapter.BindingLastOperationParams{
+		Server:     bindingsFlags.BrokerURL(),
+		InstanceID: bindingsFlags.instanceID,
+		BindingID:  bindingsFlags.bindingID,
+		LastOperationParams: &adapter.LastOperationParams{
+			APIVersion:    bindingsFlags.apiVersion,
+			ServiceID:     bindingsFlags.serviceID,
+			PlanID:        bindingsFlags.planID,
+			OperationID:   opID,
+			OperationType: opType,
+		},
+	})
+}

--- a/broker-cli/pkg/cmd/brokers.go
+++ b/broker-cli/pkg/cmd/brokers.go
@@ -1,0 +1,160 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/adapter"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	brokersFlags struct {
+		catalogs []string
+		broker   string
+		host     string
+		project  string
+		title    string
+	}
+
+	// brokersCmd represents the brokers command.
+	brokersCmd = &cobra.Command{
+		Use:   "brokers",
+		Short: "Manage service brokers",
+		Long:  "Manage service brokers",
+	}
+
+	// brokersGetCmd represents the brokers create command.
+	brokersCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a service broker",
+		Long:  "Create a service broker",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&brokersFlags.project, &brokersFlags.broker, &brokersFlags.catalogs)
+
+			// Title defaults to name if not present.
+			title := brokersFlags.title
+			if title == "" {
+				title = brokersFlags.broker
+			}
+
+			http := httpAdapterFromFlag()
+			res, err := http.CreateBroker(&adapter.CreateBrokerParams{
+				RegistryURL: brokersFlags.host,
+				Project:     brokersFlags.project,
+				Name:        brokersFlags.broker,
+				Title:       title,
+				Catalogs:    brokersFlags.catalogs,
+			})
+			processResult(res, err)
+		},
+	}
+
+	// brokersDeleteCmd represents the brokers delete command.
+	brokersDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a service broker",
+		Long:  "Delete a service broker",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&brokersFlags.project, &brokersFlags.broker)
+
+			http := httpAdapterFromFlag()
+			params := &adapter.DeleteBrokerParams{
+				RegistryURL: brokersFlags.host,
+				Project:     brokersFlags.project,
+				Name:        brokersFlags.broker,
+			}
+			err := http.DeleteBroker(params)
+			processResult(nil, err)
+		},
+	}
+
+	// brokersGetCmd represents the brokers get command.
+	brokersGetCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get a service broker",
+		Long:  "Get a service broker",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&brokersFlags.project, &brokersFlags.broker)
+
+			http := httpAdapterFromFlag()
+			res, err := http.GetBroker(&adapter.GetBrokerParams{
+				RegistryURL: brokersFlags.host,
+				Project:     brokersFlags.project,
+				Name:        brokersFlags.broker,
+			})
+			processResult(res, err)
+		},
+	}
+
+	// brokersListCmd represents the brokers list command.
+	brokersListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List service brokers for a project",
+		Long:  "List service brokers for a project",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&brokersFlags.project)
+
+			http := httpAdapterFromFlag()
+			res, err := http.ListBrokers(&adapter.ListBrokersParams{
+				RegistryURL: brokersFlags.host,
+				Project:     brokersFlags.project})
+			processResult(res, err)
+		},
+	}
+)
+
+func init() {
+	// Flags for all brokers subcommands.
+	flags.StringFlag(brokersCmd.PersistentFlags(), &brokersFlags.project, flags.ProjectLongName, flags.ProjectShortName, "[Required] The GCP Project to use.")
+	// This is defined here instead of in root so that we can define an appropriate default.
+	// Host is the hostname to use for Service Registry API calls. There's no help message here since it's a hidden flag.
+	brokersCmd.PersistentFlags().StringVar(&brokersFlags.host, flags.HostLongName, "https://serviceregistry.googleapis.com", "")
+	brokersCmd.PersistentFlags().MarkHidden(flags.HostLongName)
+
+	// Flags for brokers create.
+	flags.StringFlag(brokersCreateCmd.PersistentFlags(), &brokersFlags.broker, flags.BrokerLongName, flags.BrokerShortName, "[Required] Name of broker to create.")
+	flags.StringFlag(brokersCreateCmd.PersistentFlags(), &brokersFlags.title, "title", "t", "[Optional] Title of broker to create. Defaults to broker name")
+	// TODO(richardfung): can we make this more user friendly by not forcing them to specify projects/...?
+	// TODO(richardfung): what should the short flag actually be here?
+	flags.StringArrayFlag(brokersCreateCmd.PersistentFlags(), &brokersFlags.catalogs, "catalog", "g", "[Required] Catalogs for broker to use. Should be of the form \"projects/<project>/catalogs/<catalog>\".")
+
+	// Flags for brokers delete.
+	flags.StringFlag(brokersDeleteCmd.PersistentFlags(), &brokersFlags.broker, flags.BrokerLongName, flags.BrokerShortName, "[Required] The name of the broker.")
+
+	// Flags for brokers get.
+	flags.StringFlag(brokersGetCmd.PersistentFlags(), &brokersFlags.broker, flags.BrokerLongName, flags.BrokerShortName, "[Required] The name of the broker.")
+
+	RootCmd.AddCommand(brokersCmd)
+	brokersCmd.AddCommand(brokersCreateCmd, brokersDeleteCmd, brokersGetCmd, brokersListCmd)
+}
+
+func processResult(result interface{}, err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if result == nil {
+		return
+	}
+	marshalledRes, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshalling result\nResult: %+v\nError: %v", result, err)
+	}
+	fmt.Println(string(marshalledRes))
+}

--- a/broker-cli/pkg/cmd/catalog.go
+++ b/broker-cli/pkg/cmd/catalog.go
@@ -1,0 +1,68 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/adapter"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	catalogFlags struct {
+		flags.BrokerURLConstructor
+		apiVersion string
+	}
+	// catalogCmd represents the catalogs command.
+	catalogCmd = &cobra.Command{
+		Use:   "catalog",
+		Short: "Get broker catalog",
+		Long:  "Get broker catalog",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := httpAdapterFromFlag()
+			res, err := client.GetCatalog(&adapter.GetCatalogParams{
+				APIVersion: catalogFlags.apiVersion,
+				Server:     catalogFlags.BrokerURL(),
+			})
+			if err != nil {
+				log.Fatalf("Error getting catalog: %v\n", err)
+			}
+
+			marshalledRes, err := json.MarshalIndent(res, "", "    ")
+			if err != nil {
+				log.Fatalf("Error marshalling result\nResult: %+v\nError: %v", res, err)
+			}
+			fmt.Println(string(marshalledRes))
+		},
+	}
+)
+
+func init() {
+	flags.StringFlag(catalogCmd.PersistentFlags(), &catalogFlags.Server, flags.ServerLongName, flags.ServerShortName, fmt.Sprintf("[Required if %s and %s are not given] Broker URL to make request to (https://...).", flags.ProjectLongName, flags.BrokerLongName))
+	flags.StringFlag(catalogCmd.PersistentFlags(), &catalogFlags.Project, flags.ProjectLongName, flags.ProjectShortName, fmt.Sprintf("[Required if %s is not given] the GCP project of the broker", flags.ServerLongName))
+	flags.StringFlag(catalogCmd.PersistentFlags(), &catalogFlags.Broker, flags.BrokerLongName, flags.BrokerShortName, fmt.Sprintf("[Required if %s is not given] the broker name", flags.ServerLongName))
+	flags.StringFlagWithDefault(catalogCmd.PersistentFlags(), &catalogFlags.apiVersion, flags.ApiVersionLongName, flags.ApiVersionShortName, flags.ApiVersionDefault,
+		flags.ApiVersionDescription)
+
+	// Host is the hostname to use for Service Broker API calls. There's no help message here since it's a hidden flag.
+	catalogCmd.PersistentFlags().StringVar(&catalogFlags.Host, flags.HostLongName, flags.HostBrokerDefault, "")
+	catalogCmd.PersistentFlags().MarkHidden(flags.HostLongName)
+
+	RootCmd.AddCommand(catalogCmd)
+}

--- a/broker-cli/pkg/cmd/flags/brokerurl.go
+++ b/broker-cli/pkg/cmd/flags/brokerurl.go
@@ -1,0 +1,50 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+	"os"
+)
+
+// BrokerURLConstructor is a struct that describes the fields which can be used to
+// generate a broker URL via BrokerURL().
+type BrokerURLConstructor struct {
+	Broker  string
+	Host    string
+	Project string
+	Server  string
+}
+
+// There are two available options for service broker commands. Users are
+// allowed to pass either --server or (--project and --broker). If the latter
+// is used then we generate the URL assuming we are using a GCP broker.
+// BrokerURL checks that only one of the two options is passed
+// in, that is, only either (--server) or (--project and --broker) are used,
+// and returns the generated broker URL.
+func (flags *BrokerURLConstructor) BrokerURL() string {
+	if flags.Server == "" && (flags.Project == "" || flags.Broker == "") {
+		fmt.Printf("Either --%s or (--%s and --%s) must be provided\n", ServerLongName, ProjectLongName, BrokerLongName)
+		os.Exit(2)
+	}
+	if flags.Server != "" && flags.Project != "" && flags.Broker != "" {
+		fmt.Printf("Only one of --%s or (--%s and --%s) should be provided\n", ServerLongName, ProjectLongName, BrokerLongName)
+		os.Exit(2)
+	}
+	if flags.Server != "" {
+		return flags.Server
+	}
+	return fmt.Sprintf("%s/v1alpha1/projects/%s/brokers/%s", flags.Host, flags.Project, flags.Broker)
+}

--- a/broker-cli/pkg/cmd/flags/constants.go
+++ b/broker-cli/pkg/cmd/flags/constants.go
@@ -1,0 +1,30 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+const (
+	ApiVersionLongName    = "version"
+	ApiVersionShortName   = "v"
+	ApiVersionDefault     = "2.13"
+	ApiVersionDescription = "[Optional] The version number of OSB API the request will use."
+	BrokerLongName        = "broker"
+	BrokerShortName       = "b"
+	HostLongName          = "host"
+	HostBrokerDefault     = "https://servicebroker.googleapis.com"
+	ProjectLongName       = "project"
+	ProjectShortName      = "p"
+	ServerLongName        = "server"
+	ServerShortName       = "s"
+)

--- a/broker-cli/pkg/cmd/flags/flags.go
+++ b/broker-cli/pkg/cmd/flags/flags.go
@@ -1,0 +1,138 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Package flags is a wrapper around the pflags library which adds support
+// for required flags. You should use the *VarP functions just like with the
+// pflags package except that it's a function instead of a method. Then, you
+// can call CheckRequiredFlags to see whether any desired flags are missing.
+
+package flags
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// Names keeps the long and short flag names.
+type Names struct {
+	long  string
+	short string
+}
+
+var (
+	// nameMap is a map of flag pointers to their Names.
+	nameMap = make(map[interface{}]Names)
+)
+
+// BoolFlag is a wrapper to *FlagSet.BoolVarP which also does some book keeping so that the flag can
+// be used with GetShortName and GetLongName.
+func BoolFlag(flagset *pflag.FlagSet, p *bool, long, short, usage string) {
+	if p == nil {
+		log.Fatal("nil pointer given to RequiredBoolVarP? This should never happen")
+	}
+	nameMap[p] = Names{short: short, long: long}
+	flagset.BoolVarP(p, long, short, false /* bool flags default to FALSE */, usage)
+}
+
+// CheckFlags checks whether all given flags were specified. If any are missing this
+// will print an error message and call os.Exit(2).
+// requiredFlags should be pointers to the flag variables (e.g. &credsFlag).
+func CheckFlags(requiredFlags ...interface{}) {
+	if missingFlags := CheckRequiredFlags(requiredFlags...); missingFlags != nil {
+		PrintMissingFlags(missingFlags)
+		os.Exit(2)
+	}
+}
+
+// StringArrayFlag is a wrapper to *FlagSet.StringArrayVarP but does some additional
+// stuff so that you can use CheckRequiredFlags with the given pointer p.
+func StringArrayFlag(flagset *pflag.FlagSet, p *[]string, long, short, usage string) {
+	if p == nil {
+		log.Fatal("nil pointer given to StringArrayVarP? This should never happen")
+	}
+	nameMap[p] = Names{short: short, long: long}
+	flagset.StringArrayVarP(p, long, short, nil, usage)
+}
+
+// StringFlag is a wrapper to *FlagSet.StringVarP which also does some
+// book keeping so that the flag can be used with GetShortName and GetLongName.
+func StringFlag(flagset *pflag.FlagSet, p *string, long, short, usage string) {
+	StringFlagWithDefault(flagset, p, long, short, "", usage)
+}
+
+// StringFlagWithDefault is a wrapper to *FlagSet.StringVarP which accepts the default value for the
+// flag. It also does some book keeping so that the flag can be used with GetShortName and
+// GetLongName.
+func StringFlagWithDefault(flagset *pflag.FlagSet, p *string, long, short, defaultValue, usage string) {
+	if p == nil {
+		log.Fatal("nil pointer given to RequiredStringVarP? This should never happen")
+	}
+	nameMap[p] = Names{short: short, long: long}
+	flagset.StringVarP(p, long, short, defaultValue, usage)
+}
+
+// CheckRequiredFlags will check that all required flags are there.
+// You must use this package's *VarP functions instead of the *FlagSet methods
+// for all the flags that you are passed into this function.
+// Note that requiredFlags are not actually flags but rather pointers to the variables which are
+// set by the user flags.
+func CheckRequiredFlags(requiredFlags ...interface{}) []Names {
+	missingFlagNames := make([]Names, 0)
+	for _, requiredFlag := range requiredFlags {
+		if requiredFlag == nil {
+			log.Fatal("Null flag given? This should never happen..")
+		} else {
+			switch typedFlag := requiredFlag.(type) {
+			case *string:
+				if *typedFlag == "" {
+					missingFlagNames = addFlagName(missingFlagNames, typedFlag)
+				}
+			case *[]string:
+				if *typedFlag == nil {
+					missingFlagNames = addFlagName(missingFlagNames, typedFlag)
+				}
+			default:
+				log.Fatalf("Unknown type in CheckRequiredFlags: %v", typedFlag)
+			}
+		}
+	}
+	if len(missingFlagNames) > 0 {
+		return missingFlagNames
+	} else {
+		return nil
+	}
+}
+
+// Prints error message to user about missing flags.
+func PrintMissingFlags(missingFlags []Names) {
+	fmt.Printf("Missing required flags: %+v\nPlease use -h/--help to find more details about the flags", missingFlags)
+}
+
+func addFlagName(missingFlagNames []Names, flag interface{}) []Names {
+	names, ok := nameMap[flag]
+	if !ok {
+		// If you see this then you used this function without calling the appropriate *Flag function from this package.
+		log.Fatal("Required flag not in nameMap? This should never happen")
+	}
+	return append(missingFlagNames, names)
+}
+
+// String returns string representation of Name for pretty printing.
+// Looks like (-, --longFlag).
+func (names Names) String() string {
+	return fmt.Sprintf("(-%s, --%s)", names.short, names.long)
+}

--- a/broker-cli/pkg/cmd/instances.go
+++ b/broker-cli/pkg/cmd/instances.go
@@ -1,0 +1,314 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/adapter"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	instancesFlags struct {
+		flags.BrokerURLConstructor
+		apiVersion             string
+		instanceID             string
+		acceptsIncomplete      bool
+		serviceID              string
+		planID                 string
+		organizationGUID       string
+		spaceGUID              string
+		parameters             string
+		context                string
+		wait                   bool
+		operationID            string
+		previousServiceID      string
+		previousPlanID         string
+		previousOrganizationID string
+		previousSpaceID        string
+	}
+
+	// instancesCmd represents the instances command.
+	instancesCmd = &cobra.Command{
+		Use:   "instances",
+		Short: "Manage service instances",
+		Long:  "Manage service instances",
+	}
+
+	instancesCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a service instance",
+		Long:  "Create a service instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&instancesFlags.instanceID, &instancesFlags.serviceID, &instancesFlags.planID)
+
+			client := httpAdapterFromFlag()
+			res, err := client.CreateInstance(&adapter.CreateInstanceParams{
+				Server:            instancesFlags.BrokerURL(),
+				APIVersion:        instancesFlags.apiVersion,
+				AcceptsIncomplete: instancesFlags.acceptsIncomplete,
+				InstanceID:        instancesFlags.instanceID,
+				ServiceID:         instancesFlags.serviceID,
+				PlanID:            instancesFlags.planID,
+				Context:           parseStringToObjectMap(instancesFlags.context),
+				OrganizationGUID:  instancesFlags.organizationGUID,
+				SpaceGUID:         instancesFlags.spaceGUID,
+				Parameters:        parseStringToObjectMap(instancesFlags.parameters),
+			})
+			if err != nil {
+				log.Fatalf("Error creating instance %s: %v", instancesFlags.instanceID, err)
+			}
+
+			if !res.Async {
+				fmt.Printf("Successfully created the instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			if !instancesFlags.wait {
+				fmt.Printf("Successfully started the operation to create instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			op, err := waitOnOperation(res.OperationID, adapter.OperationCreate, client, pollInstanceLastOperation)
+			if err != nil {
+				log.Fatalf("Error polling last operation %q for instance %s: %v", res.OperationID, instancesFlags.instanceID, err)
+			}
+
+			if op.State == adapter.OperationSucceeded {
+				fmt.Printf("Successfully created the instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+				return
+			}
+
+			log.Fatalf("Failed creating instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+		},
+	}
+
+	instancesDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a service instance",
+		Long:  "Delete a service instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&instancesFlags.instanceID, &instancesFlags.serviceID, &instancesFlags.planID)
+
+			client := httpAdapterFromFlag()
+			res, err := client.DeleteInstance(&adapter.DeleteInstanceParams{
+				APIVersion:        instancesFlags.apiVersion,
+				Server:            instancesFlags.BrokerURL(),
+				AcceptsIncomplete: instancesFlags.acceptsIncomplete,
+				InstanceID:        instancesFlags.instanceID,
+				ServiceID:         instancesFlags.serviceID,
+				PlanID:            instancesFlags.planID,
+			})
+			if err != nil {
+				log.Fatalf("Error deleting instance %s: %v", instancesFlags.instanceID, err)
+			}
+
+			if !res.Async {
+				fmt.Printf("Successfully deleted the instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			if !instancesFlags.wait {
+				fmt.Printf("Successfully started the operation to delete instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			op, err := waitOnOperation(res.OperationID, adapter.OperationDelete, client, pollInstanceLastOperation)
+			if err != nil {
+				log.Fatalf("Error polling last operation %q for instance %s: %v", instancesFlags.operationID, instancesFlags.instanceID, err)
+			}
+
+			if op.State == adapter.OperationSucceeded {
+				fmt.Printf("Successfully deleted the instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+				return
+			}
+
+			log.Fatalf("Failed deleting instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+		},
+	}
+
+	instancesUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update a service instance",
+		Long:  "Update a service instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&instancesFlags.instanceID, &instancesFlags.serviceID)
+
+			client := httpAdapterFromFlag()
+			res, err := client.UpdateInstance(&adapter.UpdateInstanceParams{
+				APIVersion:             instancesFlags.apiVersion,
+				Server:                 instancesFlags.BrokerURL(),
+				AcceptsIncomplete:      instancesFlags.acceptsIncomplete,
+				InstanceID:             instancesFlags.instanceID,
+				ServiceID:              instancesFlags.serviceID,
+				PlanID:                 instancesFlags.planID,
+				Context:                parseStringToObjectMap(instancesFlags.context),
+				Parameters:             parseStringToObjectMap(instancesFlags.parameters),
+				PreviousServiceID:      instancesFlags.previousServiceID,
+				PreviousPlanID:         instancesFlags.previousPlanID,
+				PreviousOrganizationID: instancesFlags.previousOrganizationID,
+				PreviousSpaceID:        instancesFlags.previousSpaceID,
+			})
+			if err != nil {
+				log.Fatalf("Error updating instance %s: %v", instancesFlags.instanceID, err)
+			}
+
+			if !res.Async {
+				fmt.Printf("Successfully updated the instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			if !instancesFlags.wait {
+				fmt.Printf("Successfully started the operation to update instance %s: %+v\n", instancesFlags.instanceID, *res)
+				return
+			}
+
+			op, err := waitOnOperation(res.OperationID, adapter.OperationUpdate, client, pollInstanceLastOperation)
+			if err != nil {
+				log.Fatalf("Error polling last operation %q for instance %s: %v", res.OperationID, instancesFlags.instanceID, err)
+			}
+
+			if op.State == adapter.OperationSucceeded {
+				fmt.Printf("Successfully updated the instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+				return
+			}
+
+			log.Fatalf("Failed updating instance %s asynchronously (operation %q): %+v\n", instancesFlags.instanceID, res.OperationID, *op)
+		},
+	}
+
+	instancesPollCmd = &cobra.Command{
+		Use:   "poll",
+		Short: "Poll the operation for the service instance",
+		Long:  "Poll the operation for the service instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			flags.CheckFlags(&instancesFlags.instanceID)
+
+			client := httpAdapterFromFlag()
+			op, err := pollInstanceLastOperation(instancesFlags.operationID, adapter.OperationUnknown, client)
+			if err != nil {
+				log.Fatalf("Error polling operation %q for instance %s: %v", instancesFlags.operationID, instancesFlags.instanceID, err)
+			}
+
+			fmt.Printf("Successfully polled the operation %q for instance %s: %+v\n", instancesFlags.operationID, instancesFlags.instanceID, *op)
+		},
+	}
+)
+
+func init() {
+	// Flags for `instances` command group and all subgroups.
+	flags.StringFlag(instancesCmd.PersistentFlags(), &instancesFlags.Server, flags.ServerLongName, flags.ServerShortName,
+		fmt.Sprintf("[Required if %s and %s are not given] Broker URL to make request to (https://...).", flags.ProjectLongName, flags.BrokerLongName))
+	flags.StringFlag(instancesCmd.PersistentFlags(), &instancesFlags.instanceID, "instance", "i",
+		"[Required] Service instance ID.")
+	flags.StringFlagWithDefault(instancesCmd.PersistentFlags(), &instancesFlags.apiVersion,
+		flags.ApiVersionLongName, flags.ApiVersionShortName, flags.ApiVersionDefault, flags.ApiVersionDescription)
+	flags.StringFlag(instancesCmd.PersistentFlags(), &instancesFlags.Project, flags.ProjectLongName, flags.ProjectShortName,
+		fmt.Sprintf("[Required if %s is not given] the GCP project of the broker", flags.ServerLongName))
+	flags.StringFlag(instancesCmd.PersistentFlags(), &instancesFlags.Broker, flags.BrokerLongName, flags.BrokerShortName,
+		fmt.Sprintf("[Required if %s is not given] the broker name", flags.ServerLongName))
+	instancesCmd.PersistentFlags().StringVar(&instancesFlags.Host, flags.HostLongName, flags.HostBrokerDefault, "")
+	instancesCmd.PersistentFlags().MarkHidden(flags.HostLongName)
+
+	// Flags for `instances create` command group.
+	// Flags with no short names won't show up in the help message so every flag has a unique but
+	// weird short name.
+	flags.BoolFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.acceptsIncomplete, "asynchronous", "a",
+		"[Optional] If specified, the broker will execute the request asynchronously. (Default: FALSE)")
+	flags.BoolFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.wait, "wait", "w",
+		"[Optional] If specified, the broker will keep polling the last operation when the broker "+
+			"is executing the operation asynchronously. (Default: FALSE)")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.serviceID, "service", "r",
+		"[Required] The service ID used to create the service instance.")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.planID, "plan", "l",
+		"[Required] The plan ID used to create the service instance.")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.context, "context", "t",
+		"[Optional] [JSON Object] Platform specific contextual information under which the service "+
+			"instance is to be provisioned.")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.organizationGUID, "organization", "o",
+		"[Optional] [Deprecated in favor of 'Context'] The platform GUID for the organization under"+
+			" which the service instance is to be provisioned.")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.spaceGUID, "space", "e",
+		"[Optional] [Deprecated in favor of 'Context'] The identifier for the project space within "+
+			"the platform organization.")
+	flags.StringFlag(instancesCreateCmd.PersistentFlags(), &instancesFlags.parameters, "parameters", "m",
+		"[Optional] [JSON Object] Configuration options for the service instance.")
+
+	// Flags for `instances delete` command group.
+	flags.BoolFlag(instancesDeleteCmd.PersistentFlags(), &instancesFlags.acceptsIncomplete, "asynchronous", "a",
+		"[Optional] If specified, the broker will execute the request asynchronously. (Default: FALSE)")
+	flags.BoolFlag(instancesDeleteCmd.PersistentFlags(), &instancesFlags.wait, "wait", "w",
+		"[Optional] If specified, the broker will keep polling the last operation when the broker "+
+			"is executing the operation asynchronously. (Default: FALSE)")
+	flags.StringFlag(instancesDeleteCmd.PersistentFlags(), &instancesFlags.serviceID, "service", "r",
+		"[Required] The service ID used by the service instance.")
+	flags.StringFlag(instancesDeleteCmd.PersistentFlags(), &instancesFlags.planID, "plan", "l",
+		"[Required] The plan ID used by the service instance.")
+
+	// Flags for `instances update` command group.
+	flags.BoolFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.acceptsIncomplete, "asynchronous", "a",
+		"[Optional] If specified, the broker will execute the request asynchronously. (Default: FALSE)")
+	flags.BoolFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.wait, "wait", "w",
+		"[Optional] If specified, the broker will keep polling the last operation when the broker "+
+			"is executing the operation asynchronously. (Default: FALSE)")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.serviceID, "service", "r",
+		"[Required] The service ID used by the service instance.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.planID, "plan", "l",
+		"[Optional] The plan ID used by the service instance.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.context, "context", "t",
+		"[Optional] [JSON Object] Platform specific contextual information under which the service "+
+			"instance is provisioned.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.parameters, "parameters", "m",
+		"[Optional] [JSON Object] Configuration options for the service instance.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.previousServiceID, "oldservice", "f",
+		"[Optional] [Deprecated because it is immutable] The service ID used by the service instance.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.previousPlanID, "oldplan", "n",
+		"[Optional] The plan ID used by the service instance prior to the update.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.previousOrganizationID, "oldorganization", "o",
+		"[Optional] [Deprecated in favor of 'Context'] ID of the organization specified for the service instance.")
+	flags.StringFlag(instancesUpdateCmd.PersistentFlags(), &instancesFlags.previousSpaceID, "oldspace", "e",
+		"[Optional] [Deprecated in favor of 'Context'] ID of the space specified for the service instance.")
+
+	// Flags for `instances poll` command group.
+	flags.StringFlag(instancesPollCmd.PersistentFlags(), &instancesFlags.serviceID, "service", "r",
+		"[Optional] The service ID used to create the service instance. If present, must not be an empty string.")
+	flags.StringFlag(instancesPollCmd.PersistentFlags(), &instancesFlags.planID, "plan", "l",
+		"[Optional] The plan ID used to create the service instance. If present, must not be an empty string.")
+	flags.StringFlag(instancesPollCmd.PersistentFlags(), &instancesFlags.operationID, "operation", "o",
+		"[Optional] The operation ID used to poll the operation for the service instance. If present, must not be an empty string.")
+
+	RootCmd.AddCommand(instancesCmd)
+	instancesCmd.AddCommand(instancesCreateCmd)
+	instancesCmd.AddCommand(instancesDeleteCmd)
+	instancesCmd.AddCommand(instancesUpdateCmd)
+	instancesCmd.AddCommand(instancesPollCmd)
+}
+
+func pollInstanceLastOperation(opID string, opType adapter.OperationType, client adapter.Adapter) (*adapter.Operation, error) {
+	return client.InstanceLastOperation(&adapter.InstanceLastOperationParams{
+		Server:     instancesFlags.BrokerURL(),
+		InstanceID: instancesFlags.instanceID,
+		LastOperationParams: &adapter.LastOperationParams{
+			APIVersion:    instancesFlags.apiVersion,
+			ServiceID:     instancesFlags.serviceID,
+			PlanID:        instancesFlags.planID,
+			OperationID:   opID,
+			OperationType: opType,
+		},
+	})
+}

--- a/broker-cli/pkg/cmd/root.go
+++ b/broker-cli/pkg/cmd/root.go
@@ -1,0 +1,122 @@
+// Copyright © 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd contains all the commands in broker-cli
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/auth"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/client/adapter"
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/broker-cli/pkg/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+// RootCmd represents the base command when called without any subcommands.
+var (
+	RootCmd = &cobra.Command{
+		Use:   "broker-cli",
+		Short: "Service Broker Client CLI",
+		Long: "broker-cli is the client CLI for Service Broker.\n" +
+			"This application is a tool to call Service Broker\n" +
+			"APIs directly.",
+	}
+
+	// Values that are set from flags.
+	credsFlag string
+)
+
+func init() {
+	flags.StringFlag(RootCmd.PersistentFlags(), &credsFlag, "creds", "c", "[Optional] Private, json key file to use for authenticating requests. If not specified, we use gcloud authentication.")
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// httpAdapterFromFlag returns an http adapter with credentials to gcloud if
+// credsFlag is not set and to a service account if it is set.
+func httpAdapterFromFlag() *adapter.HttpAdapter {
+	var client *http.Client
+	var err error
+	ctx := context.Background()
+	if credsFlag != "" {
+		client, err = auth.HttpClientFromFile(ctx, credsFlag)
+		if err != nil {
+			log.Fatalf("Error creating http client from service account file %s: %v", credsFlag, err)
+		}
+	} else {
+		client, err = auth.HttpClientWithDefaultCredentials(ctx)
+		if err != nil {
+			log.Fatalf("Error creating http client using gcloud credentials: %v", err)
+		}
+	}
+	return adapter.NewHttpAdapter(client)
+}
+
+func parseStringToObjectMap(s string) map[string]interface{} {
+	if s == "" {
+		return nil
+	}
+
+	var objMap map[string]interface{}
+	err := json.Unmarshal([]byte(s), &objMap)
+	if err != nil {
+		log.Fatalf("Error unmarshalling string %q to object map: %v\n", s, err)
+	}
+
+	return objMap
+}
+
+func waitOnOperation(opID string, opType adapter.OperationType, client adapter.Adapter,
+	pollOperation func(string, adapter.OperationType, adapter.Adapter) (*adapter.Operation, error)) (*adapter.Operation, error) {
+	baseDelay := 100 * time.Millisecond
+	maxDelay := 6 * time.Second
+	retries := 0
+
+	curState := adapter.OperationInProgress
+	var op *adapter.Operation
+	var err error
+	for curState == adapter.OperationInProgress {
+		delay := time.Duration(math.Pow(2, float64(retries)) * float64(baseDelay))
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+		time.Sleep(delay)
+
+		op, err = pollOperation(opID, opType, client)
+		if err != nil {
+			return nil, fmt.Errorf("error polling last operation %q: %v\n", opID, err)
+		}
+
+		curState = op.State
+		retries++
+	}
+
+	// Operation states other than "in progress" are all considered as end states.
+	return op, nil
+}


### PR DESCRIPTION
This brings in new changes to the broker-cli library, and also introduces the actual CLI for managing GCP service brokers and their resources.

Fixes #75 