### PR TITLE
Add actionable error messages when users hit the confusing error

### DIFF
--- a/installer/pkg/cmd/service_catalog.go
+++ b/installer/pkg/cmd/service_catalog.go
@@ -160,6 +160,10 @@ func installServiceCatalog(ic *InstallConfig) error {
 
 	err = deployConfig(dir)
 	if err != nil {
+		if strings.Contains(err.Error(), "\"etcd-operator\" is forbidden: attempt to grant extra privileges") {
+			fmt.Println("WARNING: Please run `kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value account)` before `sc install`.")
+		}
+
 		return fmt.Errorf("error deploying YAML files: %v", err)
 	}
 


### PR DESCRIPTION
Add actionable error messages when users hit the confusing error in `sc install` command.
Now the output is:

> `$ ./output/bin/sc install`
> generated service catalog deployment config in dir: /tmp/service-catalog895050393 
> WARNING: Please run `kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value account)` before `sc install`.
> Service Catalog could not be installed
> Error: error deploying YAML files: deploy failed with output: exit status 1 :Error from server (Forbidden): error when creating "/tmp/service-catalog895050393/etcd-operator-rbac.yaml": clusterroles.rbac.authorization.k8s.io "etcd-operator" is forbidden: attempt to grant extra privileges: [PolicyRule{Resources:["etcdclusters"], APIGroups:["etcd.database.coreos.com"], Verbs:["*"]} PolicyRule{Resources:["customresourcedefinitions"], APIGroups:["apiextensions.k8s.io"], Verbs:["*"]} PolicyRule{Resources:["storageclasses"], APIGroups:["storage.k8s.io"], Verbs:["*"]} PolicyRule{Resources:["pods"], APIGroups:[""], Verbs:["*"]} PolicyRule{Resources:["services"], APIGroups:[""], Verbs:["*"]} PolicyRule{Resources:["endpoints"], APIGroups:[""], Verbs:["*"]} PolicyRule{Resources:["persistentvolumeclaims"], APIGroups:[""], Verbs:["*"]} PolicyRule{Resources:["events"], APIGroups:[""], Verbs:["*"]} PolicyRule{Resources:["deployments"], APIGroups:["apps"], Verbs:["*"]}] user=&{maqiuyu@google.com  [system:authenticated] map[]} ownerrules=[PolicyRule{Resources:["selfsubjectaccessreviews"], APIGroups:["authorization.k8s.io"], Verbs:["create"]} PolicyRule{NonResourceURLs:["/api" "/api/*" "/apis" "/apis/*" "/healthz" "/swaggerapi" "/swaggerapi/*" "/version"], Verbs:["get"]}] ruleResolutionErrors=[]

Fixes #115, fixes #67, and fixes #35.