### PR TITLE
Print default gcloud settings in sc check command

### DIFF
--- a/installer/pkg/cmd/service_catalog.go
+++ b/installer/pkg/cmd/service_catalog.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-service-catalog/installer/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-service-catalog/installer/pkg/version"
 	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"
@@ -524,7 +525,22 @@ func checkDependencies() error {
 	if len(missingCmds) > 0 {
 		return fmt.Errorf("%s commands not found in the PATH", strings.Join(missingCmds, ","))
 	}
+
+	// Also print out current account, project and zone information.
+	configs, err := gcp.GetConfigMap()
+	if err != nil {
+		return fmt.Errorf("error retrieving gcloud config: %v", err)
+	}
+
+	fmt.Printf("account: %s\n", getValueFromConfigMap("core", "account", configs))
+	fmt.Printf("project: %s\n", getValueFromConfigMap("core", "project", configs))
+	fmt.Printf("zone: %s\n", getValueFromConfigMap("compute", "zone", configs))
+
 	return nil
+}
+
+func getValueFromConfigMap(section, property string, configs map[string]interface{}) string {
+	return configs[section].(map[string]interface{})[property].(string)
 }
 
 func storageClassExists(name string) (bool, error) {

--- a/installer/pkg/gcp/broker.go
+++ b/installer/pkg/gcp/broker.go
@@ -204,3 +204,20 @@ func GetConfigValue(section, property string) (string, error) {
 	}
 	return strings.Trim(string(value), "\n"), nil
 }
+
+// GetConfigMap returns all the gcloud config in a JSON struct.
+func GetConfigMap() (map[string]interface{}, error) {
+	cmd := exec.Command("gcloud", "config", "list", "--format=json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list gcloud config : %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(output, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal gcloud config: %s : %v", string(output), err)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Fixes #113. Something else we can do is to ask for user's confirmation about all the gcloud settings while running `sc install`. This additional feature will be covered by #70.

I didn't use the existent method gcp.GetConfigValue() because I want to reduce the number of calls against `gcloud` commands. But if you think that doesn't matter, I'll reuse the existent method instead.