### PR TITLE
Enable APIs required by the GCP broker.

### DIFF
--- a/installer/pkg/gcp/broker.go
+++ b/installer/pkg/gcp/broker.go
@@ -25,9 +25,6 @@ import (
 )
 
 const (
-	DeploymentManagerAPI = "deploymentmanager.googleapis.com"
-	ServiceBrokerAPI     = "servicebroker.googleapis.com"
-
 	// The old and new command group name, and the version that made this change.
 	// See https://cloud.google.com/sdk/docs/release-notes#18800_2018-02-07 for more details.
 	oldSMCommandGroup = "service-management"


### PR DESCRIPTION
Temporarily, the APIs are enabled in add-gcp-broker command.
Long-term they will be enabled on demand.