### PR TITLE
Fix panic in `sc check` on undefined property

### DIFF
--- a/installer/pkg/cmd/service_catalog.go
+++ b/installer/pkg/cmd/service_catalog.go
@@ -542,7 +542,18 @@ func checkDependencies() error {
 }
 
 func getValueFromConfigMap(section, property string, configs map[string]interface{}) string {
-	return configs[section].(map[string]interface{})[property].(string)
+	switch s := configs[section].(type) {
+	case map[string]interface{}:
+		switch p := s[property].(type) {
+		case string:
+			return p
+		default:
+			// No value or unexpected type
+		}
+	default:
+		// No value or unexpected type.
+	}
+	return ""
 }
 
 func storageClassExists(name string) (bool, error) {


### PR DESCRIPTION
When property which `sc check` looks for is undefined,
panic ensues. Walk the parsed JSON safely to avoid panic.