### PR TITLE
Enable CloudKMS API for IAM binding type

### DIFF
--- a/installer/pkg/cmd/gcp_broker.go
+++ b/installer/pkg/cmd/gcp_broker.go
@@ -53,6 +53,7 @@ var (
 		// In the future, the APIs below will be enabled on-demand.
 		"iam.googleapis.com",
 		"bigtableadmin.googleapis.com",
+		"cloudkms.googleapis.com",
 		"cloudresourcemanager.googleapis.com",
 		"ml.googleapis.com",
 		"spanner.googleapis.com",


### PR DESCRIPTION
IAM binding needs KMS encryption on behalf of consumer project's DM SA. Thus, we should enable KMS API for customers.

Fixes #131 