### PR TITLE
Remove CloudKMS and Deployment Manager API enablement

### DIFF
--- a/installer/pkg/cmd/gcp_broker.go
+++ b/installer/pkg/cmd/gcp_broker.go
@@ -51,14 +51,13 @@ var (
 	gcpBrokerFileNames = []string{"namespace", "gcp-broker", "google-oauth-deployment", "service-account-secret", "google-oauth-rbac", "google-oauth-service-account"}
 
 	requiredAPIs = []string{
-		"deploymentmanager.googleapis.com",
+		"cloudresourcemanager.googleapis.com",
+		"iam.googleapis.com",
 		"servicebroker.googleapis.com",
 		// In the future, the APIs below will be enabled on-demand.
-		"iam.googleapis.com",
 		"bigtableadmin.googleapis.com",
-		"cloudkms.googleapis.com",
-		"cloudresourcemanager.googleapis.com",
 		"ml.googleapis.com",
+		"pubsub.googleapis.com",
 		"spanner.googleapis.com",
 		"sqladmin.googleapis.com",
 	}


### PR DESCRIPTION
- Both CloudKMS and Deployment Manager APIs are enabled as part of servicebroker API enablement for now.
- We add pubsub API in the list because the API is precisely not enabled by default; it's enabled indirectly when GKE cluster is set up.