### PR TITLE
Build cfssl from source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - go get -u -t ./installer/cmd/sc
   - go get -u github.com/jteeuwen/go-bindata/...
   - go get -u -t ./broker-cli
+  - go get -u github.com/cloudflare/cfssl/cmd/...
 
 script:
   - ./scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,12 +49,8 @@ if [[ -n "${TRAVIS_TAG}" ]]; then
 
   BIN="${TRAVIS_BUILD_DIR}/installer/output/bin"
   for pkg in cfssl cfssljson; do
-    url="https://pkg.cfssl.org/R1.2/${pkg}_${flavor}"
-    curl -o "${BIN}/${pkg}" "${url}" \
-      || { echo "Cannot download ${url}"; exit 1; }
-    curl -o "${BIN}/${pkg}.LICENSE" "https://raw.githubusercontent.com/cloudflare/cfssl/master/LICENSE" \
-      || { echo "Cannot download cfssl LICENSE"; exit 1; }
-    chmod +x "${BIN}/${pkg}"
+    cp "${GOPATH}/bin/${pkg}" "${BIN}/${pkg}"
+    cp "${GOPATH}/src/github.com/cloudflare/cfssl/LICENSE" "${BIN}/${pkg}.LICENSE"
   done
 
   tar --create --gzip \


### PR DESCRIPTION
The binary packaging of cfssl downloaded from https://pkg.cfssl.org/
seems to be malfunctioning on some versions of OSX.