### PR TITLE
Update README for case sensitivity bug

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -38,6 +38,7 @@ Before installing Service Catalog atop Kubernetes cluster, you need to ensure fo
   ```bash
   kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=<user-name>
   ```
+  _Note: The email provided to --user is case sensitive. Some older guides specify using `gcloud config get-value account`, which lowercases the email address._
 - [gcloud](https://cloud.google.com/sdk/) should be installed and configured with following
    commands in order to be used by the `sc` to configure the Service Broker.
   ```bash


### PR DESCRIPTION
Many guides around the internet, including in this repositories own issue history, suggest using `gcloud config get-value account` to get the email address. The --user option is case sensitive with respect to the email address provided. This will cause the `sc install` to fail with a verbose permissions error that makes it look like the clusterrolebinding was not created. This message will give guidance that users should check the casing of the email address provided.